### PR TITLE
Removed wrong indentation from the publish yml file

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -4,9 +4,9 @@ on:
   push:
     paths: ['CleanArchRepoTemplate.nuspec'] # Only runs when this file is modified.
     branches: [ main ]
-    workflow_run:
-      workflows: [Clean Architecture Build]
-      types: [completed]
+  workflow_run:
+    workflows: [Clean Architecture Build]
+    types: [completed]
 
 jobs:
   publish-on-build-success:

--- a/CleanArchRepoTemplate.nuspec
+++ b/CleanArchRepoTemplate.nuspec
@@ -16,7 +16,7 @@
       Creates a clean architecture project with .NET 6, Docker Compose, PostgreSQL and React using the repository pattern and, optionally, unit of work.
     </summary>
     <releaseNotes>
-      Fixed a bug related to building the .NET API project with Swagger.
+      Fixed a bug related to building the .NET API project.
     </releaseNotes>
     <packageTypes>
       <packageType name="Template" />


### PR DESCRIPTION
The `nuget-publish.yml` file had wrong indentation (#5).