### PR TITLE
Fixed the nuget-publish.yml file and refactored the build.yml file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout to Branch
+    - name: Checkout To Branch
       uses: actions/checkout@v3
 
     - name: Setup .NET 6.0.x
@@ -33,7 +33,7 @@ jobs:
         working-directory: src/client-app/
 
     steps:
-    - name: Checkout to Branch
+    - name: Checkout To Branch
       uses: actions/checkout@v3
 
     - name: Setup Node.js 16.x

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,9 +1,6 @@
 name: Publish Template to NuGet
 
 on:
-  push:
-    paths: ['CleanArchRepoTemplate.nuspec'] # Only runs when this file is modified.
-    branches: [ main ]
   workflow_run:
     workflows: [Clean Architecture Build]
     types: [completed]
@@ -12,16 +9,29 @@ jobs:
   publish-on-build-success:
     name: Publish Template to NuGet
     runs-on: windows-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ (github.event.workflow_run.conclusion == 'success') && (github.ref == 'refs/heads/main') }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: nuget/setup-nuget@v1
+      - name: Checkout To Branch
+        uses: actions/checkout@v3
+
+      - name: Get All Changed Files
+        id: changed-files
+        uses: tj-actions/changed-files@v23.1
+
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v1
         with:
           nuget-version: '5.x'
 
-      - name: Package the Template
+      - name: Package The Template
         run: nuget pack CleanArchRepoTemplate.nuspec -NoDefaultExcludes
 
-      - name: Publish to nuget.org
-        run: nuget push Gagibran.CleanArchRepo.Template.*.nupkg -src https://api.nuget.org/v3/index.json ${{ secrets.NUGET_API_KEY }}
+      - name: Publish To nuget.org
+        run: |
+            for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+              if [[ $file == CleanArchRepoTemplate.nuspec ]]; then
+                echo "$file changed. Publishing new version to nuget.org..."
+                nuget push Gagibran.CleanArchRepo.Template.*.nupkg -src https://api.nuget.org/v3/index.json ${{ secrets.NUGET_API_KEY }}
+              fi
+            done


### PR DESCRIPTION
Added conditions specifying that the workflow `Publish Template to NuGet` should only be executed when there's a commit to main and when the `CleanArchRepoTemplate.nuspec` has changed (#10).